### PR TITLE
feat: use base58 charset

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@
 
 // allowed characters for a shortcut
 export const allowedCharset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_+.'
-const genCharset = 'ABCDEFGHJKLMNOPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz0123456789-_+.'
+const genCharset = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz123456789'
 
 // check if a string is a valid url
 export const isValidHttpUrl = (str: string) => {
@@ -18,7 +18,7 @@ export const isValidHttpUrl = (str: string) => {
 // random number generator
 export const random = (upTo: number): number => Math.floor(Math.random() * upTo) + 1
 
-// generate random string, excluding I & l
+// generate random string in base58
 export const randomString = (length: number): string => {
 	const stringBuilder = []
 


### PR DESCRIPTION
Exclude O, 0, l, I and non-alphanumeric.
Easier to type for mobile users, no ambiguous characters.

old: https://short.af/6._J40
new: http://short.af/zSXgtj